### PR TITLE
(SIMP-275) Fix spec-testing issues in skeleton

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache: bundler
 before_script:
   - bundle
 script:
-  - bundle exec rake generate
   - bundle exec rake test
 notifications:
   email: false
@@ -16,10 +15,14 @@ rvm:
   - 2.1.0
   - 2.2.1
 env:
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
+  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
+  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
+  - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
+  - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
+  - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
 matrix:
   fast_finish: true
   allow_failures:
@@ -27,23 +30,53 @@ matrix:
     - rvm: 2.1.0
     - rvm: 2.2.1
     - env:
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 4.0.0"
-      - PUPPET_VERSION="~> 4.1.0"
+      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
+      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+      - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
+      - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
+      - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
+      - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
+    - rvm: 1.9.3
+      env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
+    - rvm: 2.0.0
+      env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
+
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0"
+    env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0"
+    env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
+
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+  - rvm: 2.2.1
+    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # SIMP puppet module skeleton
-[![Build Status](https://travis-ci.org/sim/puppet-module-skeleton.svg?branch=master)](https://travis-ci.org/simp/puppet-module-skeleton)
+[![Build Status](https://travis-ci.org/simp/puppet-module-skeleton.svg?branch=master)](https://travis-ci.org/simp/puppet-module-skeleton)
 
 
 This is an extremely opinionated Puppet module skeleton, forked from the fantastic [garethr/puppet-module-skeleton](https://github.com/garethr/puppet-module-skeleton).  It provides a template for the `puppet module generate` tool to generate new modules targeted toward inclusion with [SIMP](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.

--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -16,13 +16,11 @@ group :test do
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
 
-  # simp-rake-helpers does not suport puppet 2.7.X
-  # FIXME: simp-rake-helpers should support Puppet 4.X
-  if (!(['2','4'].include?( "#{ENV['PUPPET_VERSION']}".split('.').first)) &&
-      ("#{ENV['PUPPET_VERSION']}" !~ /~> ?(2|4)/ ? true : false) ) &&
+  # simp-rake-helpers does not suport puppet 2.7.X, 4+ (SIMP-208)
+  if !(['2','4'].include?("#{ENV['PUPPET_VERSION']}".scan(/\d+/).first)) &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
-      !( ENV['TRAVIS'] && RUBY_VERSION.sub(/\.\d+$/,'') == '1.8' )
+      RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'
     gem 'simp-rake-helpers'
   end
 end

--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -16,6 +16,12 @@ if Puppet.version < "4.0.0"
   end
 end
 
+
+if !ENV.key?( 'TRUSTED_NODE_DATA' )
+  warn '== WARNING: TRUSTED_NODE_DATA is unset, using TRUSTED_NODE_DATA=yes'
+  ENV['TRUSTED_NODE_DATA']='yes'
+end
+
 default_hiera_config =<<-EOM
 ---
 :backends:


### PR DESCRIPTION
Before this commit, Travis tests for this repository did not properly
propagate relevant environment variables such as PUPPET_VERSION when
spec testing the generated module.

This patch updates the rake tests to propagate the environment variables
PUPPET_VERSION, TRUSTED_NODE_DATA, STRICT_VARIABLES, and FUTURE_PARSER
to sub-tests.  It also assumes TRUSTED_NODE_DATA=yes by default (the
opposite behavior of rspec-puppet) and Travis CI now explicitly tests
for TRUSTED_NODE_DATA in both 'yes' and 'no' configurations.

SIMP-275 #comment Fixed multiple issues (SIMP-279, SIMP-280, SIMP-283)
SIMP-279 #close #comment TRUSTED_NODE_DATA specified in spec_helpers.rb
SIMP-280 #close #comment Added TRUSTED_NODE_DATA toggles to .travis.yml
SIMP-283 #close #comment Sub-tests propagate environment variables
SIMP-284 #close #comment Sub-tests can bundle under ruby 1.8.7