### PR TITLE
(SIMP-275) Allow simp-rake-helpers when Puppet 4

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -16,8 +16,8 @@ group :test do
   gem "metadata-json-lint"
   gem "simp-rspec-puppet-facts"
 
-  # simp-rake-helpers does not suport puppet 2.7.X, 4+ (SIMP-208)
-  if !(['2','4'].include?("#{ENV['PUPPET_VERSION']}".scan(/\d+/).first)) &&
+  # simp-rake-helpers does not suport puppet 2.7.X
+  if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
       # simp-rake-helpers and ruby 1.8.7 bomb Travis tests
       # TODO: fix upstream deps (parallel in simp-rake-helpers)
       RUBY_VERSION.sub(/\.\d+$/,'') != '1.8'

--- a/skeleton/README.md.erb
+++ b/skeleton/README.md.erb
@@ -25,7 +25,7 @@ _**FIXME: verify that the following paragraph fits this module's characteristics
 
 This module is optimally designed for use within a larger SIMP ecosystem, but it can be used independently:
 * When included within the SIMP ecosystem, security compliance settings will be managed from the Puppet server.
-* If used independently, all SIMP-managed security subsystems are disabled by default, and must be explicitly opted into by administrators.  Please review the `client_nets` and `$enable_*` parameters in `manifests/init.pp` for details.
+* If used independently, all SIMP-managed security subsystems are disabled by default and must be explicitly opted into by administrators.  Please review the `client_nets` and `$enable_*` parameters in `manifests/init.pp` for details.
 
 
 ## Module Description
@@ -74,7 +74,7 @@ Here, list the classes, types, providers, facts, etc contained in your module. T
 
 **FIXME:** The text below is boilerplate copy.  Ensure that it is correct and remove this message!
 
-SIMP Puppet modules are generally intended to be used on a Redhat Enterprise Linux-compatible distribution such as EL6 and EL7.  A SIMP module should
+SIMP Puppet modules are generally intended to be used on a Redhat Enterprise Linux-compatible distribution such as EL6 and EL7.
 
 ## Development
 


### PR DESCRIPTION
Before this commit, the skeleton's Gemfile used special logic to prevent
bundler from including simp-rake-helpers if the environment variable
PUPPET_VERSION was any version of Puppet 4.  This was a workaround to an
overly restrictive .gemspec in simp-rake-helpers, which was corrected in
1.0.10 (SIMP-208).

This commit removes the Puppet 4 restriction from skeleton/Gemfile.

SIMP-275 #comment Fixed SIMP-285
SIMP-285 #close #comment Gemfile allows simp-rake-helpers in Puppet 4