### PR TITLE
(SIMP-441) Mock an accessible spec environmentpath

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .yardoc
+.*.sw?
+Gemfile.lock


### PR DESCRIPTION
Before this patch, spec tests that invoked functions such as `passgen`
would attempt to write to protected locations and fail.  This commit
provides logic in `spec/spec_helpers.rb` that repoints `environmentpath`
to a temporary directory and changes the Puppet user/group to the
current user.

SIMP-441 #close Added temporay mock environmentpath directory
