### PR TITLE
(SIMP-442) Add PKI generation to acceptance tests

### DIFF
--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -36,6 +36,10 @@ group :development do
 end
 
 group :system_tests do
-  gem "beaker"
-  gem "beaker-rspec"
+  gem 'beaker'
+  gem 'beaker-rspec'
+  gem 'simp-beaker-helpers'
+  # NOTE: Workaround because net-ssh 2.10 is busting beaker
+  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
+  gem 'net-ssh', '~> 2.9.0'
 end

--- a/skeleton/spec/spec_helper_acceptance.rb.erb
+++ b/skeleton/spec/spec_helper_acceptance.rb.erb
@@ -1,4 +1,8 @@
 require 'beaker-rspec'
+require 'tmpdir'
+require 'yaml'
+require 'simp/beaker_helpers'
+include Simp::BeakerHelpers
 
 unless ENV['BEAKER_provision'] == 'no'
   hosts.each do |host|
@@ -11,47 +15,30 @@ unless ENV['BEAKER_provision'] == 'no'
   end
 end
 
-# returns an Array of puppet modules declared in .fixtures.yml
-def pupmods_in_fixtures_yaml
-  require 'yaml'
-  fixtures_yml = File.expand_path( '../.fixtures.yml', File.dirname(__FILE__))
-  data         = YAML.load_file( fixtures_yml )
-  repos        = data.fetch('fixtures').fetch('repositories').keys
-  symlinks     = data.fetch('fixtures').fetch('symlinks', {}).keys
-  (repos + symlinks)
-end
-
 
 RSpec.configure do |c|
-  # Project root
-  proj_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+  # ensure that environment OS is ready on each host
+  fix_errata_on hosts
 
   # Readable test descriptions
   c.formatter = :documentation
 
   # Configure all nodes in nodeset
   c.before :suite do
-    # net-tools required for netstat utility being used by be_listening
-    if fact('osfamily') == 'RedHat' && fact('operatingsystemmajrelease') == '7'
-      pp = <<-EOS
-        package { 'net-tools': ensure => installed }
-      EOS
+    begin
+      # Install modules and dependencies from spec/fixtures/modules
+      copy_fixture_modules_to( hosts )
 
-      apply_manifest_on(agents, pp, :catch_failures => false)
-    end
-
-    # Install module and dependencies
-    puppet_module_install(:source => proj_root, :module_name => '<%= metadata.name %>')
-    hosts.each do |host|
-      # allow spec_prep to provide modules (to support isolated networks)
-      if ENV['BEAKER_use_fixtures_dir_for_modules'] == 'yes'
-        pupmods_in_fixtures_yaml.each do |pupmod|
-          mod_root = File.expand_path( "fixtures/modules/#{pupmod}", File.dirname(__FILE__))
-          puppet_module_install(:source => mod_root, :module_name => pupmod)
-        end
+      # Generate and install PKI certificates on each SUT
+      Dir.mktmpdir do |cert_dir|
+        run_fake_pki_ca_on( default, hosts, cert_dir )
+        hosts.each{ |sut| copy_pki_to( sut, cert_dir, '/etc/pki/simp-testing' )}
+      end
+    rescue StandardError, ScriptError => e
+      if ENV['PRY']
+        require 'pry'; binding.pry
       else
-        # TODO: update when the relevant SIMP modules are on the forge
-        on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
+        raise e
       end
     end
   end


### PR DESCRIPTION
Before this path, acceptance tests did not support PKI on SUTs.  This
commit introduces the `simp-beaker-helpers` gem and updates the
`spec/spec_acceptance_helpers.rb` file to do the following:

 - copy local modules provided by `rake spec_prep`
 - generate PKI CA + certificates, and copy them into each SUT
 -

SIMP-442 #close #comment Added simp-beaker-helpers & PKI to skeleton