### PR TITLE
(SIMP-604) Migrate to simplib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,116 +15,74 @@ rvm:
   - 2.1.0
   - 2.2.1
 env:
-  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
-  - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
-  - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
-  - PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=no
-  - PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=yes
+  global:
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
   fast_finish: true
   allow_failures:
     - rvm: 1.8.7
     - rvm: 2.1.0
     - rvm: 2.2.1
-    - env:
-      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
-      - PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
-      - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
-      - PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
-      - PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=no
-      - PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
-    - rvm: 1.9.3
-      env: PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=no
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
-    - rvm: 2.0.0
-      env: PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=no
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
   # - Ruby 1.8.7 & Puppet 4.X is impossibru
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=no
+    env: PUPPET_VERSION="~> 4.0.0"
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.0.0" TRUSTED_NODE_DATA=yes
+    env: PUPPET_VERSION="~> 4.1.0"
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=no
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.1.0" TRUSTED_NODE_DATA=yes
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=no
-  - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 4.2.0" TRUSTED_NODE_DATA=yes
-
+    env: PUPPET_VERSION="~> 4.2.0"
 
   # - simp-rake-helpers deps currently break between 1.8.7 and 3.X
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+  - rvm: 1.8.7
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+
+  # Ruby 2.1.0
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.5.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.6.0"
+  - rvm: 2.1.0
+    env: PUPPET_VERSION="~> 3.7.0"
+
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.6.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.7.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.8.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=no  STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" TRUSTED_NODE_DATA=yes STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,7 @@
 #
 # SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
 # PUPPET_VERSION   | specifies the version of the puppet gem to load
+#
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : ['~>3']
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 

--- a/README.md
+++ b/README.md
@@ -2,57 +2,61 @@
 [![Build Status](https://travis-ci.org/simp/puppet-module-skeleton.svg?branch=master)](https://travis-ci.org/simp/puppet-module-skeleton)
 
 
-This is a very opinionated Puppet module skeleton, forked from the fantastic [garethr/puppet-module-skeleton](https://github.com/garethr/puppet-module-skeleton).  It provides a template for the `puppet module generate` tool to generate new modules targeted toward inclusion with [SIMP](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.
-
-## Installation
-
-As a feature, `puppet module generate` will use the path defined in the Puppet config item `module_skeleton_dir` as a template (**NOTE:** In the examples below `~/.puppet/var/puppet-module/skeleton` is used; this not universal and you should double-check your local settings before installing).
-
-As we don't want to have this repository's .git files and README in our new modules, we install the skeleton like this:
-
-    git clone https://github.com/garethr/puppet-module-skeleton
-    cd puppet-module-skeleton
-    find skeleton -type f | git checkout-index --stdin --force --prefix="$HOME/.puppet/var/puppet-module/" --
+This is a _very_ opinionated Puppet module skeleton, forked from the fantastic [garethr/puppet-module-skeleton](https://github.com/garethr/puppet-module-skeleton).  It provides a template for the `puppet module generate` tool to generate new modules targeted toward inclusion with [SIMP](https://github.com/NationalSecurityAgency/SIMP), a compliance-management framework built on Puppet.
 
 ## Usage
 
 Now, just generate your new module structure like so:
 
-    puppet module generate user-module
+    rake generate[module_name]
 
 Once you have your module then install the development dependencies:
 
     cd user-module
     bundle install
 
+
+### Rake tasks
+
 Now you should have a bunch of rake commands to help with your module
 development:
 
-    bundle exec rake -T
-    rake acceptance        # Run acceptance tests
-    rake build             # Build puppet module package
-    rake clean             # Clean a built module package
-    rake contributors      # Populate CONTRIBUTORS file
-    rake coverage          # Generate code coverage information
-    rake help              # Display the list of available rake tasks
-    rake lint              # Check puppet manifests with puppet-lint / Run puppet-lint
-    rake spec              # Run spec tests in a clean fixtures directory
-    rake spec_clean        # Clean up the fixtures directory
-    rake spec_prep         # Create the fixtures directory
-    rake spec_standalone   # Run spec tests on an existing fixtures directory
-    rake syntax            # Syntax check Puppet manifests and templates
-    rake syntax:manifests  # Syntax check Puppet manifests
-    rake syntax:templates  # Syntax check Puppet templates
+    rake acceptance                                # Run acceptance tests
+    rake beaker                                    # Run beaker acceptance tests
+    rake beaker:run[nodeset]                       # Run a Beaker test against a specific Nod...
+    rake beaker_nodes                              # List available beaker nodesets
+    rake build                                     # Build puppet module package
+    rake clean                                     # Clean a built module package / Remove an...
+    rake clobber                                   # Remove any generated file / Clobber buil...
+    rake contributors                              # Populate CONTRIBUTORS file
+    rake coverage                                  # Generate code coverage information
+    rake help                                      # Display the list of available rake tasks
+    rake lint                                      # Run puppet-lint
+    rake metadata                                  # Validate metadata.json file
+    rake pkg:rpm[chroot,unique,snapshot_release]   # Build the pupmod-simp-simplib RPM
+    rake pkg:scrub[chroot,unique]                  # Scrub the pupmod-simp-simplib mock build...
+    rake pkg:srpm[chroot,unique,snapshot_release]  # Build the pupmod-simp-simplib SRPM
+    rake pkg:tar[snapshot_release]                 # Build the pupmod-simp-simplib tar package
+    rake spec                                      # Run spec tests in a clean fixtures direc...
+    rake spec_clean                                # Clean up the fixtures directory
+    rake spec_prep                                 # Create the fixtures directory
+    rake spec_standalone                           # Run spec tests on an existing fixtures d...
+    rake syntax                                    # Syntax check Puppet manifests and templates
+    rake syntax:hiera                              # Syntax check Hiera config files
+    rake syntax:manifests                          # Syntax check Puppet manifests
+    rake syntax:templates                          # Syntax check Puppet templates
+    rake test                                      # Run syntax, lint, and spec tests
+    rake validate                                  # Check syntax of Ruby files and call :syn...
 
-Of particular interst should be:
+Of particular interest should be:
 
-* `rake spec` - run unit tests
-* `rake lint` - checks against the puppet style guide
-* `rake syntax` - to check your have valid puppet and erb syntax
+* `rake acceptance` - run acceptance tests
+* `rake spec`       - run unit tests
+* `rake test`       - run syntax, lint, and unit tests, and validate metadata
+* `rake lint`       - checks against the puppet style guide
+* `rake syntax`     - to check your have valid puppet and erb syntax
 
 ## Thanks
 
 - This module was forked from the [garethr/puppet-module-skeleton](https://github.com/garethr/puppet-module-skeleton).
-
-- The trick used in the installation above, and a few other bits came from
-another excellent module skeleton from [spiette](https://github.com/spiette/puppet-module-skeleton).
+- A few other bits came from another excellent module skeleton from [spiette](https://github.com/spiette/puppet-module-skeleton).

--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ TMP_DIR         = ENV.fetch( 'TMP_DIR', File.expand_path( 'tmp', File.dirname( _
 BUNDLER_GEMFILE = ENV.fetch( 'BUNDLER_GEMFILE', './Gemfile' )
 CLEAN << TMP_DIR
 
-if Rake.verbose
+if Rake.verbose == true
   puts "SKELETON_DIR    = '#{SKELETON_DIR}'"
   puts "PUPPET_CONF_DIR = '#{PUPPET_CONF_DIR}'"
 end

--- a/skeleton/.fixtures.yml.erb
+++ b/skeleton/.fixtures.yml.erb
@@ -1,7 +1,8 @@
+---
 fixtures:
   repositories:
     stdlib:   "https://github.com/puppetlabs/puppetlabs-stdlib.git"
     iptables: "https://github.com/simp/pupmod-simp-iptables.git"
-    common:   "https://github.com/simp/pupmod-simp-common.git"
+    simplib:   "https://github.com/simp/pupmod-simp-simplib.git"
   symlinks:
     <%= metadata.name %>: "#{source_dir}"

--- a/skeleton/.fixtures.yml.local.erb
+++ b/skeleton/.fixtures.yml.local.erb
@@ -1,0 +1,7 @@
+---
+fixtures:
+  symlinks:
+    stdlib:   "../stdlib"
+    iptables: "../iptables"
+    simplib:   "../simplib"
+    <%= metadata.name %>: "#{source_dir}"

--- a/skeleton/.puppet-lint.rc
+++ b/skeleton/.puppet-lint.rc
@@ -1,0 +1,4 @@
+--log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
+--relative
+--no-class_inherits_from_params_class-check
+--no-80chars-check

--- a/skeleton/.rspec
+++ b/skeleton/.rspec
@@ -1,2 +1,3 @@
 --format documentation
 --color
+--fail-fast

--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -1,7 +1,6 @@
 ---
 language: ruby
 cache: bundler
-fast_finish: true
 bundler_args: --without development system_tests
 before_install: rm Gemfile.lock || true
 rvm:
@@ -10,45 +9,40 @@ rvm:
   - 2.0.0
   - 2.1.0
   - 2.2.1
-###script: bundle exec rake test
 script:
     - 'bundle exec rake validate'
     - 'bundle exec rake lint'
     - 'bundle exec rake spec'
-env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - PUPPET_VERSION="~> 4.0.0"
-  - PUPPET_VERSION="~> 4.1.0"
-  - PUPPET_VERSION="~> 4.2.0"
+    - 'bundle exec rake metadata'
 
+env:
+  global: 
+    - STRICT_VARIABLES=yes
+    - TRUSTED_NODE_DATA=yes
+  matrix:
+  # NOTE: `:environmentpath` was not supported before Puppet 3.5
+    - PUPPET_VERSION="~> 3.5.0"
+    - PUPPET_VERSION="~> 3.6.0"
+    - PUPPET_VERSION="~> 3.7.0"
+    - PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 3.8.0"
+    - PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - PUPPET_VERSION="~> 4.0.0"
+    - PUPPET_VERSION="~> 4.1.0"
+    - PUPPET_VERSION="~> 4.2.0"
 matrix:
+  fast_finish: true
   allow_failures:
     - rvm: 1.8.7
     - rvm: 2.1.0
     - rvm: 2.2.1
-    - env:
-      - PUPPET_VERSION="~> 2.7.0"
-      - PUPPET_VERSION="~> 3.2.0"
-      - PUPPET_VERSION="~> 3.3.0"
-      - PUPPET_VERSION="~> 3.4.0"
-      - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-      - PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-      - PUPPET_VERSION="~> 4.0.0"
-      - PUPPET_VERSION="~> 4.1.0"
-      - PUPPET_VERSION="~> 4.2.0"
+    - env: PUPPET_VERSION="~> 3.5.0"
+    - env: PUPPET_VERSION="~> 3.6.0"
+    - env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
+    - env: PUPPET_VERSION="~> 4.0.0"
+    - env: PUPPET_VERSION="~> 4.1.0"
+    - env: PUPPET_VERSION="~> 4.2.0"
 
   exclude:
   # Ruby 1.8.7
@@ -64,67 +58,32 @@ matrix:
   # - Currently there is Gemfile logic testing for TRAVIS to avoid this.
   # - For Ruby 1.8.7, testing earliest and latest 3.X is sufficient.
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.3.0"
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_VERSION="~> 3.6.0"
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
   - rvm: 1.8.7
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-
-  # Ruby 1.9.3
-  - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
-
-  # Ruby 2.0.0
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes
 
   # Ruby 2.1.0
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
+    env: PUPPET_VERSION="~> 3.6.0"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.7.0"
 
   # Ruby 2.2.1
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 2.7.0"
-  # - No Ruby 2.2 for ~>3.X: https://tickets.puppetlabs.com/browse/PUP-3796
+    env: PUPPET_VERSION="~> 3.5.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.2.0"
+    env: PUPPET_VERSION="~> 3.6.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.3.0"
+    env: PUPPET_VERSION="~> 3.7.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_VERSION="~> 3.7.0" FUTURE_PARSER=yes
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
+    env: PUPPET_VERSION="~> 3.8.0"
   - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes
-  - rvm: 2.2.1
-    env: PUPPET_VERSION="~> 3.8.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
+    env: PUPPET_VERSION="~> 3.8.0" FUTURE_PARSER=yes

--- a/skeleton/build/pupmod-MODULENAME.spec.erb
+++ b/skeleton/build/pupmod-MODULENAME.spec.erb
@@ -7,6 +7,7 @@ Group: Applications/System
 Source: %{name}-%{version}-%{release}.tar.gz
 Buildroot: %{_tmppath}/%{name}-%{version}-%{release}-buildroot
 Requires: pupmod-iptables >= 2.0.0-0
+Requires: pupmod-simplib  >= 1.0.0-0
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 

--- a/skeleton/manifests/config/pki.pp.erb
+++ b/skeleton/manifests/config/pki.pp.erb
@@ -3,7 +3,7 @@
 # This class is meant to be called from <%= metadata.name %>.
 # It ensures that pki rules are defined.
 #
-class <%= metadata.name %>::config::config::pki {
+class <%= metadata.name %>::config::pki {
   assert_private()
 
   # FIXME: ensure your module's pki settings are defined here.

--- a/skeleton/manifests/init.pp.erb
+++ b/skeleton/manifests/init.pp.erb
@@ -106,38 +106,38 @@ class <%= metadata.name %> (
   Class[ '::<%= metadata.name %>' ]
 
   if $enable_auditing {
-   include '::<%= metadata.name %>::config::auditing'
-   Class[ '::<%= metadata.name %>::config::auditing' ] ->
-   Class[ '::<%= metadata.name %>::service' ]
+    include '::<%= metadata.name %>::config::auditing'
+    Class[ '::<%= metadata.name %>::config::auditing' ] ->
+    Class[ '::<%= metadata.name %>::service' ]
   }
 
   if $enable_firewall {
-   include '::<%= metadata.name %>::config::firewall'
-   Class[ '::<%= metadata.name %>::config::firewall' ] ->
-   Class[ '::<%= metadata.name %>::service'  ]
+    include '::<%= metadata.name %>::config::firewall'
+    Class[ '::<%= metadata.name %>::config::firewall' ] ->
+    Class[ '::<%= metadata.name %>::service'  ]
   }
 
   if $enable_logging {
-   include '::<%= metadata.name %>::config::logging'
-   Class[ '::<%= metadata.name %>::config::logging' ] ->
-   Class[ '::<%= metadata.name %>::service' ]
+    include '::<%= metadata.name %>::config::logging'
+    Class[ '::<%= metadata.name %>::config::logging' ] ->
+    Class[ '::<%= metadata.name %>::service' ]
   }
 
   if $enable_pki {
-   include '::<%= metadata.name %>::config::pki'
-   Class[ '::<%= metadata.name %>::config::pki' ] ->
-   Class[ '::<%= metadata.name %>::service' ]
+    include '::<%= metadata.name %>::config::pki'
+    Class[ '::<%= metadata.name %>::config::pki' ] ->
+    Class[ '::<%= metadata.name %>::service' ]
   }
 
   if $enable_selinux {
-   include '::<%= metadata.name %>::config::selinux'
-   Class[ '::<%= metadata.name %>::config::selinux' ] ->
-   Class[ '::<%= metadata.name %>::service' ]
+    include '::<%= metadata.name %>::config::selinux'
+    Class[ '::<%= metadata.name %>::config::selinux' ] ->
+    Class[ '::<%= metadata.name %>::service' ]
   }
 
   if $enable_tcpwrappers {
-   include '::<%= metadata.name %>::config::tcpwrappers'
-   Class[ '::<%= metadata.name %>::config::tcpwrappers' ] ->
-   Class[ '::<%= metadata.name %>::service' ]
+    include '::<%= metadata.name %>::config::tcpwrappers'
+    Class[ '::<%= metadata.name %>::config::tcpwrappers' ] ->
+    Class[ '::<%= metadata.name %>::service' ]
   }
 }

--- a/skeleton/metadata.json.erb
+++ b/skeleton/metadata.json.erb
@@ -19,7 +19,7 @@
     },
     {
       "name": "simp-simplib",
-      "version_requirement": ">= 4.1.0"
+      "version_requirement": ">= 1.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Before this commit, common SIMP-related manifests, custom facts, and
custom functions were been kept in either `simp-common` or
`simp-functions`.

This update replaces all requirements in the RPM spec file,
metadata.json, or .fixtures.yml to reflect the migration to the new
modules.

SIMP-604 #comment Updated `puppet-module-skeleton`.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/simp/puppet-module-skeleton/10)
<!-- Reviewable:end -->
