### PR TITLE
(SIMP-664) The Prefix should not be hard coded

### DIFF
--- a/skeleton/build/pupmod-MODULENAME.spec.erb
+++ b/skeleton/build/pupmod-MODULENAME.spec.erb
@@ -11,7 +11,7 @@ Requires: pupmod-simplib  >= 1.0.0-0
 Requires: puppet >= 3.3.0
 Buildarch: noarch
 
-Prefix: /etc/puppet/environments/simp/modules
+Prefix: %{_sysconfdir}/puppet/environments/simp/modules
 
 %description
 <%= metadata.summary %>


### PR DESCRIPTION
If the Prefix is hard coded, you cannot successfully relocate the
package installation path.

SIMP-664 #close
