### PR TITLE
(SIMP-1334) Ensure rake tests pass

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .yardoc
 .*.sw?
 Gemfile.lock
+tmp/

--- a/skeleton/.fixtures.yml.erb
+++ b/skeleton/.fixtures.yml.erb
@@ -1,4 +1,3 @@
----
 fixtures:
   repositories:
     stdlib:   "https://github.com/puppetlabs/puppetlabs-stdlib.git"

--- a/skeleton/.puppet-lint.rc
+++ b/skeleton/.puppet-lint.rc
@@ -1,4 +1,3 @@
 --log-format="%{path}:%{line}:%{check}:%{KIND}:%{message}"
 --relative
 --no-class_inherits_from_params_class-check
---no-80chars-check

--- a/skeleton/Gemfile
+++ b/skeleton/Gemfile
@@ -1,7 +1,10 @@
-# Variables:
-#
-# SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
-# PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# Environment variables:
+#   SIMP_GEM_SERVERS | a space/comma delimited list of rubygem servers
+#   PUPPET_VERSION   | specifies the version of the puppet gem to load
+# ------------------------------------------------------------------------------
+# NOTE: SIMP Puppet rake tasks support ruby 2.0 and ruby 2.1
+# ------------------------------------------------------------------------------
 puppetversion = ENV.key?('PUPPET_VERSION') ? "#{ENV['PUPPET_VERSION']}" : '~>3'
 gem_sources   = ENV.key?('SIMP_GEM_SERVERS') ? ENV['SIMP_GEM_SERVERS'].split(/[, ]+/) : ['https://rubygems.org']
 
@@ -11,13 +14,13 @@ group :test do
   gem "rake"
   gem 'puppet', puppetversion
   gem "rspec", '< 3.2.0'
-  gem "rspec-puppet"
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  gem "hiera-puppet-helper"
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
-  gem "simp-rspec-puppet-facts"
-
-  # dependency hacks:
-  gem "fog-google", '~> 0.0.9' # 0.1 dropped support for ruby 1.9
+  gem "simp-rspec-puppet-facts", "~> 1.3"
+  gem 'simplecov', '>= 0.11.0'
+  gem 'simplecov-console'
 
   # simp-rake-helpers does not suport puppet 2.7.X
   if "#{ENV['PUPPET_VERSION']}".scan(/\d+/).first != '2' &&
@@ -31,22 +34,19 @@ end
 group :development do
   gem "travis"
   gem "travis-lint"
-  gem "vagrant-wrapper"
+  gem "travish"
   gem "puppet-blacksmith"
   gem "guard-rake"
   gem 'pry'
   gem 'pry-doc'
+
+  # `listen` is a dependency of `guard`
+  # from `listen` 3.1+, `ruby_dep` requires Ruby version >= 2.2.3, ~> 2.2
+  gem 'listen', '~> 3.0.6'
 end
 
 group :system_tests do
   gem 'beaker'
   gem 'beaker-rspec'
-
-  # 1.0.5 introduces FIPS-first acc tests
   gem 'simp-beaker-helpers', '>= 1.0.5'
-
-  # dependency hacks:
-  # NOTE: Workaround because net-ssh 2.10 is busting beaker
-  # lib/ruby/1.9.1/socket.rb:251:in `tcp': wrong number of arguments (5 for 4) (ArgumentError)
-  gem 'net-ssh', '~> 2.9.0'
 end


### PR DESCRIPTION
- Updated the Gemfiles to reflect the latest rspec puppet and simp Gemfiles.
- Removed 80 char check from lint, not a valid option.
- Updated fixtures.

SIMP-1334 #close
