### PR TITLE
(SIMP-1373) Fix rspec coverage report for Travis-CI

### DIFF
--- a/skeleton/spec/classes/coverage_spec.rb
+++ b/skeleton/spec/classes/coverage_spec.rb
@@ -1,1 +1,0 @@
-at_exit { RSpec::Puppet::Coverage.report! }

--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -145,6 +145,10 @@ RSpec.configure do |c|
     FileUtils.rm_rf(@spec_global_env_temp)
     @spec_global_env_temp = nil
   end
+
+  c.after(:suite) do
+    RSpec::Puppet::Coverage.report!
+  end
 end
 
 Dir.glob("#{RSpec.configuration.module_path}/*").each do |dir|


### PR DESCRIPTION
This moves the coverage report for rspec-puppet to the `after(:suite)`
hook in RSpec.  Previously it was called via `Kernel#at_exit`, but the
global nature of that method is not thread-safe and caused failures in
some environments when run with `parallel_tests`, notably Travis-CI.
