### PR TITLE
Fix data type for $enable_pki.

### DIFF
--- a/skeleton/manifests/init.pp.erb
+++ b/skeleton/manifests/init.pp.erb
@@ -53,7 +53,7 @@ class <%= metadata.name %> (
   String                        $package_name       = '<%= metadata.name %>',
   Simplib::Port                 $tcp_listen_port    = 9999,
   Simplib::Netlist              $trusted_nets       = simplib::lookup('simp_options::trusted_nets', {'default_value' => ['127.0.0.1/32'] }),
-  Boolean                       $enable_pki         = simplib::lookup('simp_options::pki', { 'default_value'         => false }),
+  Variant[Boolean,Enum['simp']] $enable_pki         = simplib::lookup('simp_options::pki', { 'default_value'         => false }),
   Boolean                       $enable_auditing    = simplib::lookup('simp_options::auditd', { 'default_value'      => false }),
   Variant[Boolean,Enum['simp']] $enable_firewall    = simplib::lookup('simp_options::firewall', { 'default_value'    => false }),
   Boolean                       $enable_logging     = simplib::lookup('simp_options::syslog', { 'default_value'      => false }),


### PR DESCRIPTION
With this change, a generated module will pass tests out of the box.