### PR TITLE
(SIMP-MAINT) Update RVM version + trivial fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@
 # https://puppet.com/docs/pe/2018.1/overview/getting_support_for_pe.html
 ---
 language: ruby
-sudo: false
 cache: bundler
 before_script:
   - bundle update

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ stages:
   - test
 
 jobs:
+  fast_finish: true
   include:
     - stage: test
       name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
@@ -41,6 +42,3 @@ jobs:
       env: 'PUPPET_VERSION="~>6.10.0"'
       script:
         - bundle exec rake test
-
-matrix:
-  fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ jobs:
   include:
     - stage: test
       name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: 'PUPPET_VERSION="~> 5.5.0"'
       script:
         - bundle exec rake test

--- a/skeleton/.travis.yml
+++ b/skeleton/.travis.yml
@@ -84,7 +84,7 @@ jobs:
   include:
     - stage: check
       name: 'Syntax, style, and validation checks'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5"
       script:
         - bundle exec rake check:dot_underscore
@@ -97,7 +97,7 @@ jobs:
         - bundle exec puppet module build
 
     - stage: spec
-      rvm: 2.4.5
+      rvm: 2.4.9
       name: 'Puppet 5.5 (SIMP 6.4, PE 2018.1)'
       env: PUPPET_VERSION="~> 5.5.0"
       script:
@@ -105,7 +105,7 @@ jobs:
 
     - stage: spec
       name: 'Puppet 5.x (Latest)'
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.0"
       script:
         - bundle exec rake spec
@@ -118,7 +118,7 @@ jobs:
         - bundle exec rake spec
 
     - stage: deploy
-      rvm: 2.4.5
+      rvm: 2.4.9
       env: PUPPET_VERSION="~> 5.5.0"
       script:
         - true

--- a/skeleton/spec/spec_helper.rb
+++ b/skeleton/spec/spec_helper.rb
@@ -91,12 +91,8 @@ RSpec.configure do |c|
     }
   }
 
-  c.mock_framework = :rspec
-  c.mock_with :rspec
-
   c.module_path = File.join(fixture_path, 'modules')
   c.manifest_dir = File.join(fixture_path, 'manifests')
-
   c.hiera_config = File.join(fixture_path,'hieradata','hiera.yaml')
 
   # Useless backtrace noise


### PR DESCRIPTION
This patch updates the RVM version used in the project and skeleton
pipelines to 2.4.9

It includes two other trivial fixes:

* Removes superfluous mock-related RSpec configs from the
  skeleton's spec_helper.rb
* Fixes a bug in the main project's Travis CI pipeline that prevents
  build stages from running
